### PR TITLE
Update bluetooth-ds4-ds5-workaround

### DIFF
--- a/bluetooth-ds4-ds5-workaround
+++ b/bluetooth-ds4-ds5-workaround
@@ -130,10 +130,10 @@ monitor_gamepad() {
     fi
 
     # Define the command to disconnect all controllers
-    disconnect_cmd="for controller in \$(bluetoothctl list | awk '/Controller/ {print \$2}'); do echo -e \"select \$controller\ndisconnect $bluetooth_mac_address\n\" | bluetoothctl; done"
+    disconnect_cmd="bluetoothctl disconnect $bluetooth_mac_address"
 
     # Run the monitoring process with a specific process name
-    (cat "$device_path" 2>&1 | xxd -p -c 24 | awk -v mac="$bluetooth_mac_address" -v pname="$process_name" -v cmd="$disconnect_cmd" -v debug="$DEBUG" '
+    (stdbuf -i0 -o0 -e0 cat "$device_path" 2>&1 | stdbuf -i0 -o0 -e0 xxd -p -c 24 | awk -v mac="$bluetooth_mac_address" -v pname="$process_name" -v cmd="$disconnect_cmd" -v debug="$DEBUG" '
         BEGIN { home_pressed=0; triangle_pressed=0 }
         {
             event_part=substr($0,33);


### PR DESCRIPTION
use stdbuf for faster detection of pressed buttons and updated bluetoothctl command to disconnect controller on new version of bluez, which no longer retrieves Controller* from a bluetoothctl list command.